### PR TITLE
v1.2.3

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
       matrix:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ schema = pdc.infer_schema(df)
 df_new = pdc.coerce_df(df, schema)
 ```
 
-Smaller data types -> smaller memory footprint.
+Smaller data types $\Rightarrow$ smaller memory footprint.
 
 ```python
 df.info()
@@ -110,7 +110,7 @@ print(pdc.options.RTOL)
 # >>> 1e-05
 ```
 
-Tolerance can be set at module level or passed in function arguments.
+Tolerance can be set at the module level or passed in function arguments.
 
 ```python
 pdc.options.ATOL = 1e-10

--- a/pdcast/__init__.py
+++ b/pdcast/__init__.py
@@ -29,8 +29,8 @@ Examples:
 
 """
 
-__author__ = """Dominic Thorn"""
+__author__ = "Dominic Thorn"
 __email__ = "dominic.thorn@gmail.com"
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 from pdcast.core import coerce_df, coerce_series, downcast, infer_schema, options

--- a/pdcast/core.py
+++ b/pdcast/core.py
@@ -152,7 +152,7 @@ def infer_schema(
     data: Union[DataFrame, Series],
     include: Optional[Iterable[Hashable]] = None,
     exclude: Optional[Iterable[Hashable]] = None,
-    sample_size: int = 10_000,
+    sample_size: Optional[int] = None,
     numpy_dtypes_only: Optional[bool] = None,
     infer_dtype_kws: Optional[Dict[str, Any]] = None,
 ) -> Dict[Any, Any]:
@@ -163,7 +163,7 @@ def infer_schema(
         include: Columns to include. (Default value = None)
             Excludes all other columns if defined.
         exclude: Columns to exclude. (Default value = None)
-        sample_size: Number of records to take from head and tail. (Default value = 10_000)
+        sample_size: Number of records to take from head and tail. (Default value = None)
         numpy_dtypes_only: Use only Numpy dtypes for schema. (Default value = None)
         infer_dtype_kws: Keyword arguments for `infer_dtype`. (Default value = None)
 
@@ -394,7 +394,7 @@ def type_cast_valid(
         atol: Relative tolerance for numeric equality. (Default value = None)
 
     Returns:
-        True if type if valid, False otherwise.
+        True if type is valid, False otherwise.
 
     """
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandas-downcast"
-version = "1.2.2"
+version = "1.2.3"
 description = "Shrink Pandas DataFrames with precision safe schema inference."
 authors = ["Dominic Thorn <dominic.thorn@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Set the default sample size to `None` to avoid casting to an incompatible type.
Fixes issue: "IntCastingNaNError: Cannot convert non-finite values (NA or inf) to integer" #10